### PR TITLE
export 'TsAppVersion' interface and 'versions' object, add 'name' and 'description' from package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ With that setup the file is updated when `npm start` and `npm build` are run.
 The script generates a TypeScript file at the location `./src/_versions.ts` if you haven't provided a different location.
 You'll be able to import the values just like any other package:
 ```
-import versions from '../_versions';
+import { versions, TsAppVersion } from '../_versions';
 ```
 
 The file will export an object with following variables:

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ import { versions, TsAppVersion } from '../_versions';
 The file will export an object with following variables:
 
 * **version** is the version from the packages.json (e.g. v1.0.0)
+* **name** is the name from the packages.json (e.g. 'sample-app')
+* **description** is the description from the packages.json
 * **versionDate** is the timestamp in ISO format when the compilation/package started.
 * **versionLong** is the version from the packages.json PLUS the Hash of the current Git-Commit (e.g. v1.0.0-g63962e3) - will only be generated if your repository is a Git Repository
 * **gitTag** is the latest Git tag

--- a/dist/index.js
+++ b/dist/index.js
@@ -54,12 +54,12 @@ const appVersion = require(packageFile).version;
 
 console.log('[TsAppVersion] ' + colors.green('Application version (from package.json): ') + colors.yellow(appVersion));
 let src = `interface TsAppVersion {
-    version: string,
-    versionLong?: string,
-    versionDate: string,
-    gitCommitHash?: string,
-    gitCommitDate?: string,
-    gitTag?: string,
+    version: string;
+    versionLong?: string;
+    versionDate: string;
+    gitCommitHash?: string;
+    gitCommitDate?: string;
+    gitTag?: string;
 }
 const obj: TsAppVersion = {
     version: '${appVersion}',
@@ -121,7 +121,8 @@ if (enableGit) {
     }
 }
 
-src += `export default obj;`;
+src += `export default obj;
+`;
 
 console.log('[TsAppVersion] ' + colors.green('Writing version module to ') + colors.yellow(versionFile));
 fs.writeFile(versionFile, src, function (err) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -70,7 +70,7 @@ let src = `export interface TsAppVersion {
 }
 export const versions: TsAppVersion = {
     version: '${appVersion}',
-    name: '${appName}',    
+    name: '${appName}',
     versionDate: '${new Date().toISOString()}',
 `;
 if (appDescription !== undefined && appDescription !== '') {

--- a/dist/index.js
+++ b/dist/index.js
@@ -50,10 +50,18 @@ const outputFile = argv.hasOwnProperty('file') ? argv.file : path.join('src', '_
 const versionFile = path.join(projectFolder, outputFile);
 
 // pull version from package.json
-const appVersion = require(packageFile).version;
+const pkg = require(packageFile); 
+const appVersion = pkg.version;
+const appName = pkg.name;
+const appDescription = pkg.description;
 
 console.log('[TsAppVersion] ' + colors.green('Application version (from package.json): ') + colors.yellow(appVersion));
+console.log('[TsAppVersion] ' + colors.green('Application description (from package.json): ') + colors.yellow(appName));
+
+let src = `export interface TsAppVersion {
     version: string;
+    name: string;
+    description?: string;
     versionLong?: string;
     versionDate: string;
     gitCommitHash?: string;
@@ -62,8 +70,13 @@ console.log('[TsAppVersion] ' + colors.green('Application version (from package.
 }
 export const versions: TsAppVersion = {
     version: '${appVersion}',
-    versionDate: '${new Date().toISOString()}'
+    name: '${appName}',    
+    versionDate: '${new Date().toISOString()}',
 `;
+if (appDescription !== undefined && appDescription !== '') {
+    console.log('[TsAppVersion] ' + colors.green('Application description (from package.json): ') + colors.yellow(appDescription));
+    src += `    description: '${appDescription}',\n`;
+}
 
 let enableGit = false;
 let gitFolder = projectFolder;

--- a/dist/index.js
+++ b/dist/index.js
@@ -53,7 +53,6 @@ const versionFile = path.join(projectFolder, outputFile);
 const appVersion = require(packageFile).version;
 
 console.log('[TsAppVersion] ' + colors.green('Application version (from package.json): ') + colors.yellow(appVersion));
-let src = `interface TsAppVersion {
     version: string;
     versionLong?: string;
     versionDate: string;
@@ -61,10 +60,9 @@ let src = `interface TsAppVersion {
     gitCommitDate?: string;
     gitTag?: string;
 }
-const obj: TsAppVersion = {
+export const versions: TsAppVersion = {
     version: '${appVersion}',
     versionDate: '${new Date().toISOString()}'
-};
 `;
 
 let enableGit = false;
@@ -87,7 +85,7 @@ if (enableGit) {
         let versionWithHash = appVersion;
         if (info.hasOwnProperty('hash')) {
             versionWithHash = versionWithHash + '-' + info.hash;
-            src += `obj.gitCommitHash = '${info.hash}';\n`;
+            src += `    gitCommitHash: '${info.hash}',\n`;
             console.log('[TsAppVersion] ' + colors.green('Git Commit hash: ') + colors.yellow(info.hash));
 
             // Get date of commit
@@ -100,17 +98,17 @@ if (enableGit) {
                 if (gitCommit.hasOwnProperty('date')) {
                     const gitDateString = new Date(gitCommit.date).toISOString();
                     console.log('[TsAppVersion] ' + colors.green('Git Commit date: ') + colors.yellow(gitDateString));
-                    src += `obj.gitCommitDate = '${gitDateString}';\n`;
+                    src += `    gitCommitDate: '${gitDateString}',\n`;
                 }
             } catch (e) {
                 console.log(e);
             }
         }
         console.log('[TsAppVersion] ' + colors.green('Long Git version: ') + colors.yellow(versionWithHash));
-        src += `obj.versionLong = '${versionWithHash}';\n`;
+        src += `    versionLong: '${versionWithHash}',\n`;
         if (info.hasOwnProperty('tag')) {
             console.log('[TsAppVersion] ' + colors.green('Git tag: ') + colors.yellow(info.tag));
-            src += `obj.gitTag = '${info.tag}';\n`;
+            src += `    gitTag: '${info.tag}',\n`;
         }
     } catch(e) {
         if (new RegExp(/Not a git repository/).test(e.message)) {
@@ -121,7 +119,7 @@ if (enableGit) {
     }
 }
 
-src += `export default obj;
+src += `};
 `;
 
 console.log('[TsAppVersion] ' + colors.green('Writing version module to ') + colors.yellow(versionFile));

--- a/test/index.js
+++ b/test/index.js
@@ -55,8 +55,8 @@ describe('appversion', function() {
                 return;
             }
             const fileContents = fs.readFileSync(outputFile, 'utf8');
-            expect(fileContents).to.contains('version: \'1.0.0\'');
-            expect(fileContents).not.to.contains('obj.versionLong = \'1.0.0-');
+            expect(fileContents).to.contains('version: \'1.0.0\',');
+            expect(fileContents).not.to.contains('versionLong = \'1.0.0-');
             done();
         });
     });
@@ -81,9 +81,10 @@ describe('appversion', function() {
                 return;
             }
             const fileContents = fs.readFileSync(outputFile, 'utf8');
-            expect(fileContents).to.contains('version: \'1.0.0\'');
-            expect(fileContents).to.contains('obj.versionLong = \'1.0.0-');
-            expect(fileContents).to.not.contains('obj.versionLong = \'1.0.0-\'');
+            expect(fileContents).to.contains('export const versions: TsAppVersion =');
+            expect(fileContents).to.contains('version: \'1.0.0\',');
+            expect(fileContents).to.contains('versionLong: \'1.0.0-');
+            expect(fileContents).to.not.contains('versionLong: \'1.0.0-\'');
             done();
         });
     });
@@ -108,9 +109,10 @@ describe('appversion', function() {
                 return;
             }
             const fileContents = fs.readFileSync(outputFile, 'utf8');
-            expect(fileContents).to.contains('version: \'1.0.0\'');
-            expect(fileContents).to.contains('obj.versionLong = \'1.0.0-');
-            expect(fileContents).to.not.contains('obj.versionLong = \'1.0.0-\'');
+            expect(fileContents).to.contains('export const versions: TsAppVersion =');
+            expect(fileContents).to.contains('version: \'1.0.0\',');
+            expect(fileContents).to.contains('versionLong: \'1.0.0-');
+            expect(fileContents).to.not.contains('versionLong: \'1.0.0-\'');
             done();
         });
     });
@@ -136,9 +138,10 @@ describe('appversion', function() {
                 return;
             }
             const fileContents = fs.readFileSync(outputFile, 'utf8');
+            expect(fileContents).to.contains('export const versions: TsAppVersion =');
             expect(fileContents).to.contains('version: \'1.0.0\'');
-            expect(fileContents).to.contains('obj.versionLong = \'1.0.0-');
-            expect(fileContents).to.not.contains('obj.versionLong = \'1.0.0-\'');
+            expect(fileContents).to.contains('versionLong: \'1.0.0-');
+            expect(fileContents).to.not.contains('versionLong: \'1.0.0-\'');
             done();
         });
     });

--- a/test/index.js
+++ b/test/index.js
@@ -38,7 +38,7 @@ describe('appversion', function() {
 
     it('should succeed with default settings and without a Git repository', function(done) {
         fs.mkdirSync(path.join(repoDir, 'src'), {recursive: true});
-        fs.writeFileSync(path.join(repoDir, 'package.json'), '{"version": "1.0.0"}');
+        fs.writeFileSync(path.join(repoDir, 'package.json'), '{"version": "1.0.0", "name": "test", "description": "test description"}');
         exec('node dist/index.js --root=' + repoDir, (err, stdout, stderr) => {
             if (err) {
                 done('Test failed: Could not execute command.');
@@ -56,6 +56,8 @@ describe('appversion', function() {
             }
             const fileContents = fs.readFileSync(outputFile, 'utf8');
             expect(fileContents).to.contains('version: \'1.0.0\',');
+            expect(fileContents).to.contains('name: \'test\',');
+            expect(fileContents).to.contains('description: \'test description\',');
             expect(fileContents).not.to.contains('versionLong = \'1.0.0-');
             done();
         });
@@ -64,7 +66,7 @@ describe('appversion', function() {
     it('should succeed with default settings', function(done) {
         repo.init();
         fs.mkdirSync(path.join(repoDir, 'src'));
-        fs.writeFileSync(path.join(repoDir, 'package.json'), '{"version": "1.0.0"}');
+        fs.writeFileSync(path.join(repoDir, 'package.json'), '{"version": "1.0.0", "name": "test", "description": "test description"}');
         exec('node dist/index.js --root=' + repoDir, (err, stdout, stderr) => {
             if (err) {
                 done('Test failed: Could not execute command.');
@@ -83,16 +85,47 @@ describe('appversion', function() {
             const fileContents = fs.readFileSync(outputFile, 'utf8');
             expect(fileContents).to.contains('export const versions: TsAppVersion =');
             expect(fileContents).to.contains('version: \'1.0.0\',');
+            expect(fileContents).to.contains('name: \'test\',');
+            expect(fileContents).to.contains('description: \'test description\',');
             expect(fileContents).to.contains('versionLong: \'1.0.0-');
             expect(fileContents).to.not.contains('versionLong: \'1.0.0-\'');
             done();
         });
     });
 
+    it('should succeed with default settings when no description is provided', function(done) {
+        repo.init();
+        fs.mkdirSync(path.join(repoDir, 'src'));
+        fs.writeFileSync(path.join(repoDir, 'package.json'), '{"version": "1.0.0", "name": "test"}');
+        exec('node dist/index.js --root=' + repoDir, (err, stdout, stderr) => {
+            if (err) {
+                done('Test failed: Could not execute command.');
+                return;
+            }
+            if (stderr) {
+                done(stderr);
+                return;
+            }
+            expect(stdout).to.match(/Writing version module to/);
+            const outputFile = path.join(repoDir, 'src', '_versions.ts');
+            if (!fs.existsSync(outputFile)) {
+                done('File ' + outputFile + ' not found.');
+                return;
+            }
+            const fileContents = fs.readFileSync(outputFile, 'utf8');
+            expect(fileContents).to.contains('export const versions: TsAppVersion =');
+            expect(fileContents).to.contains('version: \'1.0.0\',');
+            expect(fileContents).to.contains('name: \'test\',');
+            expect(fileContents).to.contains('versionLong: \'1.0.0-');
+            expect(fileContents).to.not.contains('versionLong: \'1.0.0-\'');
+            expect(fileContents).to.not.contains('description: \'');
+            done();
+        });
+    });
 
     it('should succeed with different file output', function(done) {
         repo.init();
-        fs.writeFileSync(path.join(repoDir, 'package.json'), '{"version": "1.0.0"}');
+        fs.writeFileSync(path.join(repoDir, 'package.json'), '{"version": "1.0.0", "name": "test", "description": "test description"}');
         exec('node dist/index.js --root=' + repoDir + ' --file=version-test.ts', (err, stdout, stderr) => {
             if (err) {
                 done('Test failed: Could not execute command.');
@@ -111,6 +144,8 @@ describe('appversion', function() {
             const fileContents = fs.readFileSync(outputFile, 'utf8');
             expect(fileContents).to.contains('export const versions: TsAppVersion =');
             expect(fileContents).to.contains('version: \'1.0.0\',');
+            expect(fileContents).to.contains('name: \'test\',');
+            expect(fileContents).to.contains('description: \'test description\',');
             expect(fileContents).to.contains('versionLong: \'1.0.0-');
             expect(fileContents).to.not.contains('versionLong: \'1.0.0-\'');
             done();
@@ -122,7 +157,7 @@ describe('appversion', function() {
         const applicationDir = path.join(repoDir, 'application');
         fs.mkdirSync(applicationDir);
         fs.mkdirSync(path.join(applicationDir, 'src'));
-        fs.writeFileSync(path.join(applicationDir, 'package.json'), '{"version": "1.0.0"}');
+        fs.writeFileSync(path.join(applicationDir, 'package.json'), '{"version": "1.0.0", "name": "test", "description": "test description"}');
         exec('node dist/index.js --root=' + applicationDir + ' --git=..', (err, stdout, stderr) => {
             if (err) {
                 done('Test failed: Could not execute command.');
@@ -140,6 +175,8 @@ describe('appversion', function() {
             const fileContents = fs.readFileSync(outputFile, 'utf8');
             expect(fileContents).to.contains('export const versions: TsAppVersion =');
             expect(fileContents).to.contains('version: \'1.0.0\'');
+            expect(fileContents).to.contains('name: \'test\'');
+            expect(fileContents).to.contains('description: \'test description\'');
             expect(fileContents).to.contains('versionLong: \'1.0.0-');
             expect(fileContents).to.not.contains('versionLong: \'1.0.0-\'');
             done();


### PR DESCRIPTION
- allow export 'TsAppVersion' interface and 'versions' object, instead 'versions' only.
Now you should use `import { versions, TsAppVersion } from '../_versions';` instead of `import versions from '../_versions';`

-  export 'name' and 'description' fields from package.json file
The _version file looks like those below:
```
export interface TsAppVersion {
    version: string;
    name: string;
    description?: string;
    versionLong?: string;
    versionDate: string;
    gitCommitHash?: string;
    gitCommitDate?: string;
    gitTag?: string;
}
export const versions: TsAppVersion = {
    version: '1.0.0',
    name: 'sample-app',    
    versionDate: '2020-03-28T23:22:47.277Z',
};

```
or
```
export interface TsAppVersion {
    version: string;
    name: string;
    description: string;
    versionLong?: string;
    versionDate: string;
    gitCommitHash?: string;
    gitCommitDate?: string;
    gitTag?: string;
}
export const versions: TsAppVersion = {
    version: '1.3.0',
    name: '@saithodev/ts-appversion',
    description: 'Reads the version from your packages.json and saves it in a .ts file you can include into your application.',
    versionDate: '2020-03-28T22:52:20.612Z',
    gitCommitHash: 'ga5f9362',
    gitCommitDate: '2020-03-28T21:37:04.000Z',
    versionLong: '1.3.0-ga5f9362',
    gitTag: 'v2.0.0',
};
```

For both of points above:
- update dist/index.js
- update tests to cover new cases: new export syntax and name, description filed
- update README.md