### PR TITLE
improve typescript import

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,9 @@ You'll be able to import the values just like any other package, if you want use
 ```
 import versions from '../_versions';
 ```
-or you can import also TsAppVersion and use direclty in your template, like in app.component.ts example file
+or you can import also TsAppVersion and use directly in your template, like in app.component.ts example file
 ```
-import { TsAppVersion } from 'src/_versions.ts';
-import versions from 'src/_versions.ts';
+import { TsAppVersion, versions } from 'src/_versions.ts';
 
 @Component({
   selector: 'app-root',

--- a/dist/index.js
+++ b/dist/index.js
@@ -68,7 +68,7 @@ let src = `export interface TsAppVersion {
     gitCommitDate?: string;
     gitTag?: string;
 };
-const obj: TsAppVersion = {
+export const versions: TsAppVersion = {
     version: '${appVersion}',
     name: '${appName}',
     versionDate: '${new Date().toISOString()}',
@@ -133,7 +133,7 @@ if (enableGit) {
 }
 
 src += `};
-export default obj;
+export default versions;
 `;
 
 console.log('[TsAppVersion] ' + colors.green('Writing version module to ') + colors.yellow(versionFile));

--- a/dist/index.js
+++ b/dist/index.js
@@ -56,7 +56,7 @@ const appName = pkg.name;
 const appDescription = pkg.description;
 
 console.log('[TsAppVersion] ' + colors.green('Application version (from package.json): ') + colors.yellow(appVersion));
-console.log('[TsAppVersion] ' + colors.green('Application description (from package.json): ') + colors.yellow(appName));
+console.log('[TsAppVersion] ' + colors.green('Application name (from package.json): ') + colors.yellow(appName));
 
 let src = `export interface TsAppVersion {
     version: string;

--- a/example/src/app/app.component.ts
+++ b/example/src/app/app.component.ts
@@ -1,8 +1,7 @@
 import { Component } from '@angular/core';
 import { environment } from "../environments/environment";
 
-import { TsAppVersion } from 'src/_versions';
-import versions from 'src/_versions';
+import { TsAppVersion, versions } from 'src/_versions';
 
 @Component({
   selector: 'app-root',

--- a/test/index.js
+++ b/test/index.js
@@ -66,13 +66,13 @@ describe('appversion', function() {
             expect(fileContents).to.contains('gitCommitHash?: string;');
             expect(fileContents).to.contains('gitCommitDate?: string;');
             expect(fileContents).to.contains('gitTag?: string;');
-            expect(fileContents).to.contains('};\nconst obj: TsAppVersion = {');        // interface end + obj start
+            expect(fileContents).to.contains('};\nexport const versions: TsAppVersion = {');        // interface end + obj start
 
             // data test
             expect(fileContents).to.contains('version: \'1.0.0\',');
             expect(fileContents).to.contains('name: \'test\',');
             expect(fileContents).to.contains('description: \'test description\',');
-            expect(fileContents).to.contains('};\nexport default obj;\n');              // export default obj + file close
+            expect(fileContents).to.contains('};\nexport default versions;\n');              // export default obj + file close
             expect(fileContents).not.to.contains('versionLong = \'1.0.0-');
 
             done();
@@ -109,14 +109,14 @@ describe('appversion', function() {
             expect(fileContents).to.contains('gitCommitHash?: string;');
             expect(fileContents).to.contains('gitCommitDate?: string;');
             expect(fileContents).to.contains('gitTag?: string;');
-            expect(fileContents).to.contains('};\nconst obj: TsAppVersion = {');        // interface end + obj start
+            expect(fileContents).to.contains('};\nexport const versions: TsAppVersion = {');        // interface end + obj start
 
             // data test
             expect(fileContents).to.contains('version: \'1.0.0\',');
             expect(fileContents).to.contains('name: \'test\',');
             expect(fileContents).to.contains('description: \'test description\',');
             expect(fileContents).to.contains('versionLong: \'1.0.0-');
-            expect(fileContents).to.contains('};\nexport default obj;\n');              // export default obj + file close
+            expect(fileContents).to.contains('};\nexport default versions;\n');              // export default obj + file close
             expect(fileContents).to.not.contains('versionLong: \'1.0.0-\'');
 
             done();
@@ -153,14 +153,14 @@ describe('appversion', function() {
             expect(fileContents).to.contains('gitCommitHash?: string;');
             expect(fileContents).to.contains('gitCommitDate?: string;');
             expect(fileContents).to.contains('gitTag?: string;');
-            expect(fileContents).to.contains('};\nconst obj: TsAppVersion = {');        // interface end + obj start
+            expect(fileContents).to.contains('};\nexport const versions: TsAppVersion = {');        // interface end + obj start
 
             // data test
             expect(fileContents).to.contains('version: \'1.0.0\',');
             expect(fileContents).to.contains('name: \'test\',');
             expect(fileContents).to.contains('versionLong: \'1.0.0-');
             expect(fileContents).to.not.contains('versionLong: \'1.0.0-\'');
-            expect(fileContents).to.contains('};\nexport default obj;\n');              // export default obj + file close
+            expect(fileContents).to.contains('};\nexport default versions;\n');              // export default obj + file close
             expect(fileContents).to.not.contains('description: \'');
 
             done();
@@ -196,14 +196,14 @@ describe('appversion', function() {
             expect(fileContents).to.contains('gitCommitHash?: string;');
             expect(fileContents).to.contains('gitCommitDate?: string;');
             expect(fileContents).to.contains('gitTag?: string;');
-            expect(fileContents).to.contains('};\nconst obj: TsAppVersion = {');        // interface end + obj start
+            expect(fileContents).to.contains('};\nexport const versions: TsAppVersion = {');        // interface end + obj start
 
             // data test
             expect(fileContents).to.contains('version: \'1.0.0\',');
             expect(fileContents).to.contains('name: \'test\',');
             expect(fileContents).to.contains('description: \'test description\',');
             expect(fileContents).to.contains('versionLong: \'1.0.0-');
-            expect(fileContents).to.contains('};\nexport default obj;\n');              // export default obj + file close
+            expect(fileContents).to.contains('};\nexport default versions;\n');              // export default obj + file close
             expect(fileContents).to.not.contains('versionLong: \'1.0.0-\'');
 
             done();
@@ -241,14 +241,14 @@ describe('appversion', function() {
             expect(fileContents).to.contains('gitCommitHash?: string;');
             expect(fileContents).to.contains('gitCommitDate?: string;');
             expect(fileContents).to.contains('gitTag?: string;');
-            expect(fileContents).to.contains('};\nconst obj: TsAppVersion = {');        // interface end + obj start
+            expect(fileContents).to.contains('};\nexport const versions: TsAppVersion = {');        // interface end + obj start
 
             // data test
             expect(fileContents).to.contains('version: \'1.0.0\'');
             expect(fileContents).to.contains('name: \'test\'');
             expect(fileContents).to.contains('description: \'test description\'');
             expect(fileContents).to.contains('versionLong: \'1.0.0-');
-            expect(fileContents).to.contains('};\nexport default obj;\n');              // export default obj + file close
+            expect(fileContents).to.contains('};\nexport default versions;\n');              // export default obj + file close
 
             expect(fileContents).to.not.contains('versionLong: \'1.0.0-\'');
 


### PR DESCRIPTION
- fix typo: logged 'description' instead of 'name' on dist/index.js
- let able to import _versions.ts content either as typescript module via "import { ... } form '..' " either via default import (as is for environment.ts files)